### PR TITLE
Fixed bug causing exception

### DIFF
--- a/SessionStorageManager.php
+++ b/SessionStorageManager.php
@@ -44,11 +44,11 @@ class SessionStorageManager implements StorageListManagerInterface
 
     public function hasStorageList(): bool
     {
-        return $this->$this->requestStack->getSession()->has($this->name);
+        return $this->requestStack->getSession()->has($this->name);
     }
 
     public function persist(StorageListInterface $storageList): void
     {
-        $this->$this->requestStack->getSession()->set($this->name, $storageList);
+        $this->requestStack->getSession()->set($this->name, $storageList);
     }
 }


### PR DESCRIPTION
Found an error in code before the member variable 'requestStack'

```
public function hasStorageList(): bool
{
    return $this->$this->requestStack->getSession()->has($this->name);
}

public function persist(StorageListInterface $storageList): void
{
    $this->$this->requestStack->getSession()->set($this->name, $storageList);
}
```

This error created the following error:
`Object of class CoreShop\Component\StorageList\SessionStorageManager could not be converted to string`